### PR TITLE
Allow queries with date ranges exceeding max days per request

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,9 @@
 import streamlit as st
-import streamlit.components.v1 as components
-from fitbit import hr
-from fitbit import o2
-from fitbit import rr
-from fitbit import hrv
+
+from fitbit import get_breathing_rate
+from fitbit import get_heart_rate
+from fitbit import get_heart_rate_variability
+from fitbit import get_oxygen_saturation
 
 st.image("Vito.png")
 st.header("Vito Study")
@@ -42,7 +42,6 @@ st.caption(link)
 fitbitResponse = st.text_input("Enter Response From Fitbit Authorization")
 
 if fitbitResponse != "":
-
     parsed = fitbitResponse.split("#access_token=")[1]
 
     token = parsed.split("&user_id")[0]
@@ -50,7 +49,7 @@ if fitbitResponse != "":
     user_id = parsed.split("&user_id=")[1].split("&")[0]
     st.write(user_id)
 
-    st.write(hr("2020-01-01", "2022-01-08", token, user_id))
-    st.write(rr("2020-01-01", "2022-01-08", token, user_id))
-    st.write(hrv("2020-01-01", "2022-01-08", token, user_id))
-    st.write(o2("2020-01-01", "2022-01-08", token, user_id))
+    st.write(get_heart_rate(token, user_id, "2020-01-01", "2022-01-08"))
+    st.write(get_breathing_rate(token, user_id, "2020-01-01", "2022-01-08"))
+    st.write(get_heart_rate_variability(token, user_id, "2020-01-01", "2022-01-08"))
+    st.write(get_oxygen_saturation(token, user_id, "2020-01-01", "2022-01-08"))


### PR DESCRIPTION
Fixes #4 

## Changes
- Expanded abbreviated function names to add clarity
- Added get() function to reduce duplicate code
- Added option to specify the maximum days per request to allow for queries to BR and HRV that have date ranges exceeding 30 days

Note: when I query my own data, the BR, HRV, and SpO2 responses are empty, as shown below (the SpO2 response contains a list, which correctly corresponds to the example response in the API reference). I believe this is because my account does not contain data for those measurements, but it could be due to errors in my code, so you may want to test it for yourself; however, it displayed the correct data when I tried querying my HR data using 30 days per request, so it seems to be working correctly. Also, it takes a few seconds to load the data due to the high number of requests that must be processed.

![data](https://user-images.githubusercontent.com/48031522/183980653-60e9b33c-2025-4634-bb2c-7c333c7101bf.png)